### PR TITLE
Add prepare-pull-request script to automate PR creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repo uses the terms **porcelain** and **plumbing** to describe its scripts,
   - [Fetch GitHub Conversation](#fetch-github-conversation)
   - [Summarize GitHub Conversation](#summarize-github-conversation)
   - [Prepare Commit](#prepare-commit)
+  - [Prepare Pull Request](#prepare-pull-request)
 - **Plumbing**: Lower-level scripts intended to be used by other scripts or for advanced workflows.
   - [Select Folder](#select-folder)
 
@@ -142,6 +143,23 @@ This script helps you generate a semantic commit message for your staged changes
   --commit-message-prompt-path /path/to/commit-prompt.txt \
   [--llm-model MODEL]
 ```
+
+### Prepare Pull Request
+
+This script helps you generate a pull request title and body based on commits between your current branch and the base branch. It uses an LLM to analyze your commit messages and diffs to generate a meaningful PR description. You can review and edit both the title and body before creating the PR using the GitHub CLI. If you choose not to create the PR immediately, the title and body are copied to your clipboard for later use.
+
+**Usage:**
+
+```sh
+/path/to/scripts/bin/prepare-pull-request \
+  --base-branch main \
+  --pr-body-prompt-path /path/to/pr-prompt.txt \
+  [--llm-model MODEL]
+```
+
+- `--base-branch`: The name of the base branch to compare against (e.g., main, master, develop)
+- `--pr-body-prompt-path`: Path to the prompt file for generating the PR body
+- `--llm-model`: (Optional) Specify a specific LLM model to use
 
 ## Plumbing Commands
 

--- a/bin/prepare-pull-request
+++ b/bin/prepare-pull-request
@@ -1,0 +1,244 @@
+#!/usr/bin/env ruby
+
+# bin/prepare-pull-request: Prepare a pull request using commits between HEAD and base branch, using LLM to generate content.
+#
+# It allows the user to generate a PR title and body based on commit messages, review them, and then create the PR.
+# The script uses the GitHub CLI to open the PR once the user is satisfied with the content.
+#
+# Usage: prepare-pull-request --base-branch BRANCH --pr-body-prompt-path PATH [--llm-model MODEL]
+
+require "open3"
+require "optparse"
+require "shellwords"
+require "tempfile"
+
+# --- Helper Methods ---
+
+# Exits the script with an error message.
+#
+# message - The String error message to display.
+#
+# Returns nothing. Exits the script.
+def error_exit(message)
+  puts "Error: #{message}"
+  exit 1
+end
+
+# Checks if a required command-line dependency is available in PATH.
+#
+# cmd - The String name of the command to check.
+#
+# Returns nothing. Exits if not found.
+def check_dependency(cmd)
+  system("which #{cmd} > /dev/null 2>&1") || error_exit("Required dependency '#{cmd}' not found in PATH.")
+end
+
+# Gets the commit messages and changes between HEAD and the base branch.
+#
+# base_branch - The String name of the base branch to compare against.
+#
+# Returns the commit log and diff as a String.
+def get_commit_context(base_branch)
+  log_output, log_status = Open3.capture2("git log --reverse --pretty=format:'%h %s%n%b' #{base_branch}..HEAD")
+  error_exit("Failed to get commit log, are you on a branch with commits?") unless log_status.success?
+
+  diff_output, diff_status = Open3.capture2("git diff #{base_branch}...HEAD")
+  error_exit("Failed to get diff between branches") unless diff_status.success?
+
+  context = "# Commit messages between '#{base_branch}' and 'HEAD':\n\n"
+  context += log_output
+  context += "\n\n# Summary of changes:\n\n"
+
+  # Get a summary of files changed
+  files_changed, _ = Open3.capture2("git diff --name-status #{base_branch}...HEAD")
+  context += files_changed
+
+  return context
+end
+
+# Returns the model flag for the llm command, or an empty string if no model is specified.
+#
+# llm_model - The String model name or nil.
+#
+# Returns a String suitable for the llm command.
+def llm_model_flag(llm_model)
+  llm_model && !llm_model.strip.empty? ? "-m #{Shellwords.escape(llm_model)}" : ""
+end
+
+# Generates a PR title and body using the LLM, given the prompt and commit context.
+#
+# prompt_path - The String path to the PR body prompt template.
+# context     - The String commit context to provide as input.
+# llm_model   - The String model name or nil.
+#
+# Returns a Hash with the generated title and body.
+def generate_pr_content(prompt_path, context, llm_model)
+  prompt_content = File.read(prompt_path)
+
+  Tempfile.create(["llm_pr_prompt", ".txt"]) do |tmp|
+    tmp.puts prompt_content
+    tmp.flush
+    model_flag = llm_model_flag(llm_model)
+    cmd = "llm #{model_flag} -f #{tmp.path}"
+
+    output, _ = Open3.capture2(cmd, stdin_data: context)
+
+    # Extract title and body from the output
+    lines = output.strip.split("\n")
+    title = lines.first.strip
+    body = lines[2..-1].join("\n").strip if lines.length > 2
+
+    return { title: title, body: body }
+  end
+end
+
+# Copies the given text to the macOS clipboard using pbcopy.
+#
+# text - The String to copy.
+#
+# Returns nothing.
+def copy_to_clipboard(text)
+  IO.popen("pbcopy", "w") { |f| f << text }
+end
+
+# Edit the provided text using the user's editor.
+#
+# text - The String text to edit.
+#
+# Returns the edited text as a String.
+def edit_text(text)
+  Tempfile.create(["pr_edit", ".md"]) do |tmp|
+    tmp.puts text
+    tmp.flush
+
+    editor = ENV["EDITOR"] || "nano"
+    system("#{editor} #{tmp.path}")
+
+    return File.read(tmp.path)
+  end
+end
+
+# Checks if the current branch has a remote tracking branch.
+#
+# Returns a Boolean indicating if the branch has a remote.
+def has_remote_branch?
+  output, status = Open3.capture2("git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null")
+  status.success? && !output.strip.empty?
+end
+
+# Creates a pull request using the GitHub CLI.
+#
+# title - The String PR title.
+# body  - The String PR body.
+# base  - The String base branch name.
+#
+# Returns nothing.
+def create_pull_request(title, body, base)
+  unless has_remote_branch?
+    error_exit("Current branch does not have a remote tracking branch. Push your branch first with 'git push -u origin HEAD'.")
+  end
+
+  Tempfile.create(["pr_body", ".md"]) do |tmp|
+    tmp.puts body
+    tmp.flush
+
+    puts "Creating pull request..."
+    result = system("gh", "pr", "create", "--title", title, "--body-file", tmp.path, "--base", base)
+    error_exit("Failed to create pull request.") unless result
+
+    puts "Pull request created successfully!"
+  end
+end
+
+# === Main Script ===
+
+# Step 1: Parse command-line options
+options = {}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: prepare-pull-request [options]"
+  opts.on("--base-branch=BRANCH", "Name of the base branch (required)") do |b|
+    options[:base_branch] = b
+  end
+  opts.on("--pr-body-prompt-path=PATH", "Path to PR body prompt template (required)") do |p|
+    options[:prompt] = p
+  end
+  opts.on("--llm-model MODEL", "Model alias to use for llm -m (optional)") do |model|
+    options[:llm_model] = model
+  end
+end.parse!
+
+# Step 2: Validate required options
+if options[:base_branch].nil? || options[:base_branch].strip.empty?
+  error_exit("You must provide a base branch name using --base-branch.")
+end
+
+prompt_path = options[:prompt]
+prompt_path = File.expand_path(prompt_path) if prompt_path
+if prompt_path.nil? || prompt_path.strip.empty? || !File.exist?(prompt_path)
+  error_exit("You must provide a valid path to the PR body prompt template using --pr-body-prompt-path.")
+end
+
+# Step 3: Check dependencies
+check_dependency("git")
+check_dependency("gh")
+check_dependency("llm")
+
+# Step 4: Get commit context
+puts "Getting commit context between #{options[:base_branch]} and HEAD..."
+context = get_commit_context(options[:base_branch])
+
+# Step 5: Generate PR title and body using LLM
+puts "Generating PR content using LLM..."
+pr_content = generate_pr_content(prompt_path, context, options[:llm_model])
+puts "Generated PR title: #{pr_content[:title]}"
+puts "\nGenerated PR body:\n\n#{pr_content[:body]}"
+
+# Step 6: Let user review and edit the title
+loop do
+  print "\nDo you want to edit the PR title? (y/n): "
+  yn = gets.strip.downcase
+  if yn == "y"
+    print "Enter a new PR title: "
+    pr_content[:title] = gets.strip
+    puts "New PR title: #{pr_content[:title]}"
+  elsif yn == "n"
+    break
+  else
+    puts "Please answer y or n."
+  end
+
+  print "Are you satisfied with the PR title? (y/n): "
+  yn = gets.strip.downcase
+  break if yn == "y"
+end
+
+# Step 7: Let user review and edit the PR body
+loop do
+  print "Do you want to edit the PR body? (y/n): "
+  yn = gets.strip.downcase
+  if yn == "y"
+    puts "Opening editor to edit PR body..."
+    pr_content[:body] = edit_text(pr_content[:body])
+    puts "PR body updated."
+  elsif yn == "n"
+    break
+  else
+    puts "Please answer y or n."
+  end
+
+  print "Are you satisfied with the PR body? (y/n): "
+  yn = gets.strip.downcase
+  break if yn == "y"
+end
+
+# Step 8: Ask whether to create the PR now
+print "Do you want to create the PR now? (y/n): "
+yn = gets.strip.downcase
+if yn == "y"
+  create_pull_request(pr_content[:title], pr_content[:body], options[:base_branch])
+else
+  puts "PR content has been prepared but not submitted. You can create the PR manually."
+  puts "Title and body have been copied to clipboard."
+  copy_to_clipboard("#{pr_content[:title]}\n\n#{pr_content[:body]}")
+end

--- a/bin/prepare-pull-request
+++ b/bin/prepare-pull-request
@@ -126,6 +126,21 @@ def has_remote_branch?
   status.success? && !output.strip.empty?
 end
 
+# Pushes the current branch to origin and sets up tracking.
+#
+# Returns a Boolean indicating success or failure.
+def push_branch
+  puts "Pushing current branch to remote..."
+  result = system("git push -u origin HEAD")
+  if result
+    puts "Branch pushed successfully!"
+    return true
+  else
+    puts "Failed to push branch. Please check your remote configuration."
+    return false
+  end
+end
+
 # Creates a pull request using the GitHub CLI.
 #
 # title - The String PR title.
@@ -135,7 +150,15 @@ end
 # Returns nothing.
 def create_pull_request(title, body, base)
   unless has_remote_branch?
-    error_exit("Current branch does not have a remote tracking branch. Push your branch first with 'git push -u origin HEAD'.")
+    print "Current branch is not pushed to remote. Push branch now? (y/n): "
+    yn = gets.strip.downcase
+    if yn == "y"
+      unless push_branch
+        error_exit("Cannot create pull request without pushing branch.")
+      end
+    else
+      error_exit("Cannot create pull request without pushing branch.")
+    end
   end
 
   Tempfile.create(["pr_body", ".md"]) do |tmp|

--- a/bin/prepare-pull-request
+++ b/bin/prepare-pull-request
@@ -101,7 +101,7 @@ def copy_to_clipboard(text)
   IO.popen("pbcopy", "w") { |f| f << text }
 end
 
-# Edit the provided text using the user's editor.
+# Edit the provided text using the editor configured in git.
 #
 # text - The String text to edit.
 #
@@ -111,7 +111,14 @@ def edit_text(text)
     tmp.puts text
     tmp.flush
 
-    editor = ENV["EDITOR"] || "nano"
+    # Try to get the editor from git config, then fall back to EDITOR env var, and finally to nano
+    git_editor, git_editor_status = Open3.capture2("git config --get core.editor")
+    editor = if git_editor_status.success? && !git_editor.strip.empty?
+      git_editor.strip
+    else
+      ENV["EDITOR"] || "nano"
+    end
+
     system("#{editor} #{tmp.path}")
 
     return File.read(tmp.path)

--- a/bin/prepare-pull-request
+++ b/bin/prepare-pull-request
@@ -156,16 +156,24 @@ end
 #
 # Returns nothing.
 def create_pull_request(title, body, base)
-  unless has_remote_branch?
+  # Check if branch has remote tracking
+  remote_exists = has_remote_branch?
+
+  # Ask to push only if there's no remote branch
+  if !remote_exists
     print "Current branch is not pushed to remote. Push branch now? (y/n): "
     yn = gets.strip.downcase
-    if yn == "y"
-      unless push_branch
-        error_exit("Cannot create pull request without pushing branch.")
-      end
-    else
+    if yn.downcase != "y"
       error_exit("Cannot create pull request without pushing branch.")
     end
+  else
+    # If remote already exists, always push to ensure latest commits are there
+    puts "Ensuring remote branch is up-to-date..."
+  end
+
+  # Push the branch with tracking
+  unless push_branch
+    error_exit("Cannot create pull request without pushing branch.")
   end
 
   Tempfile.create(["pr_body", ".md"]) do |tmp|


### PR DESCRIPTION
## Why?
- Creating pull requests is repetitive and time-consuming, especially when summarizing recent changes and following best-practice templates.
- The process was missing automation for generating a clear/consistent PR title and description from commit history and code diffs.

## How?
- Introduce a new `prepare-pull-request` script that:
  - Gathers recent commits/diffs and generates a title/body for the PR using an LLM (via the `llm` CLI), with a customizable prompt. See [`bin/prepare-pull-request`](bin/prepare-pull-request).
  - Allows review and editing of generated content, defaulting to the user’s `git core.editor` if set; else `$EDITOR` or `nano`. See [ad4c5be](https://github.com/jonmagic/scripts/pull/11/commits/ad4c5be).
  - Prompts the user to push the local branch to origin before PR creation if it is not tracked, improving reliability. See [411b1d4](https://github.com/jonmagic/scripts/pull/11/commits/411b1d4).
  - Ensures latest commits are pushed to origin before creating the PR, preventing stale or missing commits. See [032fd3a6](https://github.com/jonmagic/scripts/pull/11/commits/032fd3a6c1d50046ad73f005d1e7631273552510)
- Updates `README.md` with usage instructions.

### Testing
- Manually tested the script by running it on several branches:
  - Verified the branch-push prompt appears when appropriate.
  - Checked LLM generation step and that the editor selection falls back as expected.
  - Confirmed PR body/title editing and successful PR creation or clipboard fallback.
