### PR TITLE
Hierarchical Personal Reflection Pipeline & CLI Orchestration

### DIFF
--- a/bin/reflection-agent
+++ b/bin/reflection-agent
@@ -1,0 +1,184 @@
+#!/usr/bin/env ruby
+
+# reflection-agent - Generate personal work reflections using hierarchical summarization
+#
+# This script orchestrates a multi-stage workflow that creates comprehensive reflections
+# by analyzing weekly snippets and referenced GitHub conversations. It uses a hierarchical
+# summarization approach to scale from 1 week to 2+ years of reflection.
+#
+# Usage:
+#   bin/reflection-agent [OPTIONS]
+#
+# Examples:
+#   # Two week catch-up (default)
+#   bin/reflection-agent
+#
+#   # Custom date range
+#   bin/reflection-agent --start-date 2025-04-01 --end-date 2025-09-30
+#
+#   # Six month reflection
+#   bin/reflection-agent --start-date 2025-01-01 --end-date 2025-06-30 \
+#                        --purpose "H1 2025 Reflection" \
+#                        --name "h1-2025"
+#
+#   # Resume from existing reflection
+#   bin/reflection-agent --resume-from ~/brain/Reflections/bromine-semester
+#
+# Prerequisites:
+#   - Qdrant vector database running at localhost:6333
+#   - GitHub conversation cache at ~/code/jonmagic/scripts/data
+#   - Brain folder with Snippets/ at ~/brain
+#   - Vector index up-to-date (run update script first)
+
+require "optparse"
+require "date"
+require_relative "../lib/reflection_agent"
+require_relative "../lib/log"
+
+# Default paths
+DEFAULT_CACHE_PATH = File.expand_path("~/code/jonmagic/scripts/data")
+DEFAULT_COLLECTION = "github-conversations"
+DEFAULT_BRAIN_PATH = File.expand_path("~/brain")
+
+# Parse command line options
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: bin/reflection-agent [OPTIONS]"
+  opts.separator ""
+  opts.separator "Generate personal work reflections using hierarchical summarization"
+  opts.separator ""
+  opts.separator "Options:"
+
+  opts.on("--cache-path PATH", "Path to GitHub conversation cache (default: #{DEFAULT_CACHE_PATH})") do |v|
+    options[:cache_path] = v
+  end
+
+  opts.on("--collection NAME", "Qdrant collection name (default: #{DEFAULT_COLLECTION})") do |v|
+    options[:collection] = v
+  end
+
+  opts.on("--brain-path PATH", "Path to brain folder (default: #{DEFAULT_BRAIN_PATH})") do |v|
+    options[:brain_path] = v
+  end
+
+  opts.on("--start-date DATE", "Start date YYYY-MM-DD (default: 14 days ago)") do |v|
+    options[:start_date] = v
+  end
+
+  opts.on("--end-date DATE", "End date YYYY-MM-DD (default: today)") do |v|
+    options[:end_date] = v
+  end
+
+  opts.on("--purpose PURPOSE", "Purpose of reflection (default: catch-up)") do |v|
+    options[:purpose] = v
+  end
+
+  opts.on("--name NAME", "Reflection name (default: catch-up-YYYY-MM-DD)") do |v|
+    options[:reflection_name] = v
+  end
+
+  opts.on("--resume-from PATH", "Resume from existing reflection directory") do |v|
+    options[:resume_from] = v
+  end
+
+  opts.on("--llm-model MODEL", "LLM model for summaries (default: ENV['LLM_MODEL'])") do |v|
+    options[:llm_model] = v
+  end
+
+  opts.on("--executive-summary-prompt PATH", "Path to executive summary prompt") do |v|
+    options[:executive_summary_prompt_path] = v
+  end
+
+  opts.on("--topics-prompt PATH", "Path to topics extraction prompt") do |v|
+    options[:topics_prompt_path] = v
+  end
+
+  opts.on("-v", "--verbose", "Show debug logs") do
+    options[:verbose] = true
+  end
+
+  opts.on("-h", "--help", "Show this help message") do
+    puts opts
+    exit
+  end
+end.parse!
+
+# Apply defaults
+options[:cache_path] ||= DEFAULT_CACHE_PATH
+options[:collection] ||= DEFAULT_COLLECTION
+options[:brain_path] ||= DEFAULT_BRAIN_PATH
+options[:executive_summary_prompt_path] ||= File.expand_path("~/code/jonmagic/prompts/summarize/github-conversation-executive-summary.md")
+options[:topics_prompt_path] ||= File.expand_path("~/code/jonmagic/prompts/generate/topics.md")
+
+# Validate paths exist
+unless File.directory?(options[:cache_path])
+  abort "Error: cache_path does not exist: #{options[:cache_path]}"
+end
+
+unless File.directory?(options[:brain_path])
+  abort "Error: brain_path does not exist: #{options[:brain_path]}"
+end
+
+snippets_path = File.join(options[:brain_path], "Snippets")
+unless File.directory?(snippets_path)
+  abort "Error: Snippets folder not found: #{snippets_path}"
+end
+
+# Validate prompt files exist
+unless File.exist?(options[:executive_summary_prompt_path])
+  abort "Error: Executive summary prompt not found: #{options[:executive_summary_prompt_path]}"
+end
+
+unless File.exist?(options[:topics_prompt_path])
+  abort "Error: Topics prompt not found: #{options[:topics_prompt_path]}"
+end
+
+# Setup logging
+if options[:verbose]
+  Log.logger.level = Logger::DEBUG
+end
+
+# Display banner
+puts ""
+puts "=" * 70
+puts "  PERSONAL WORK REFLECTION AGENT v2"
+puts "  Hierarchical Summarization: Snippets → Clusters → Synthesis"
+puts "=" * 70
+puts ""
+puts "Configuration:"
+puts "  Cache:      #{options[:cache_path]}"
+puts "  Collection: #{options[:collection]}"
+puts "  Brain:      #{options[:brain_path]}"
+puts "  LLM Model:  #{options[:llm_model] || ENV['LLM_MODEL'] || 'default'}"
+puts ""
+
+if options[:resume_from]
+  puts "  Resuming:   #{options[:resume_from]}"
+  puts ""
+else
+  start_date = options[:start_date] || (Date.today - 14).to_s
+  end_date = options[:end_date] || Date.today.to_s
+  puts "  Date Range: #{start_date} to #{end_date}"
+  puts "  Purpose:    #{options[:purpose] || 'catch-up'}"
+  puts ""
+end
+
+puts "⚠️  IMPORTANT: Ensure your vector index is up-to-date before running!"
+puts "   This agent loads conversation summaries from Qdrant."
+puts ""
+puts "Press Ctrl+C to cancel, or wait 3 seconds to continue..."
+sleep 3
+puts ""
+
+# Run the workflow
+begin
+  ReflectionAgent.start(options)
+rescue Interrupt
+  puts ""
+  puts "Interrupted by user"
+  exit 1
+rescue => e
+  Log.logger.error "Fatal error: #{e.message}"
+  Log.logger.error e.backtrace.join("\n") if options[:verbose]
+  exit 1
+end

--- a/lib/reflection_agent.rb
+++ b/lib/reflection_agent.rb
@@ -1,0 +1,154 @@
+# ReflectionAgent - Personal Work Reflection Pipeline (v2)
+#
+# ## Architecture Overview
+# This module orchestrates a hierarchical summarization workflow for creating personal
+# work reflections. It starts with curated weekly snippets as the source of truth,
+# then expands to include referenced GitHub conversations through clustered summarization.
+#
+# ### Core Design Principles
+# - **Snippets First**: Weekly snippets are the primary signal (you curated them!)
+# - **Hierarchical Summarization**: Break large datasets into clusters, summarize each
+# - **Bounded Context**: Each LLM call stays under 30KB to avoid context limits
+# - **Scalable**: Works for 1 week to 2+ years of reflection
+#
+# ### Pipeline Stages
+# 1. **InitializeNode**: Creates session structure and metadata
+# 2. **SnippetsLoaderNode**: Loads all snippets within date range
+# 3. **SnippetsClusterNode**: Groups snippets into 4-6 temporal clusters
+# 4. **ClusterSnippetSummaryNode**: Summarizes each cluster's snippets (parallel)
+# 5. **ConversationsLoaderNode**: Extracts URLs from snippets, loads from vector DB
+# 6. **ClusterConversationSummaryNode**: Summarizes conversations per cluster (parallel)
+# 7. **FinalSynthesisNode**: Combines all cluster summaries into final reflection
+# 8. **EndNode**: Completion summary and next steps
+#
+# ### Data Flow
+# ```
+# Snippets (26) → Clusters (5) → Cluster Summaries (5 × 2KB = 10KB)
+#                              ↓
+# URLs Extracted → Conversations Loaded (260) → Scored → Top 50 per cluster
+#                                                       ↓
+#                             Cluster Conversation Summaries (5 × 2KB = 10KB)
+#                                                       ↓
+#                             Final Synthesis (10KB + 10KB = 20KB) ✅
+# ```
+#
+# ### Key Optimizations
+# - **Parallel processing**: Cluster summarization uses `ParallelBatchNode`
+# - **Smart filtering**: Only top N conversations per cluster reach LLM
+# - **Incremental summarization**: Each stage writes checkpoint for resumability
+# - **Context preservation**: Original top snippets included in final synthesis
+#
+# For detailed node documentation, see each class in `lib/reflection_agent/`.
+
+require "json"
+require "logger"
+require "open3"
+require "date"
+require "fileutils"
+require "shellwords"
+
+require_relative "log"
+require_relative "pocketflow"
+require_relative "utils"
+
+require_relative "reflection_agent/initialize_node"
+require_relative "reflection_agent/snippets_loader_node"
+require_relative "reflection_agent/snippets_cluster_node"
+require_relative "reflection_agent/cluster_snippet_summary_node"
+require_relative "reflection_agent/conversations_loader_node"
+require_relative "reflection_agent/cluster_conversation_summary_node"
+require_relative "reflection_agent/final_synthesis_node"
+require_relative "reflection_agent/end_node"
+
+module ReflectionAgent
+  # Start the reflection workflow with the given options
+  #
+  # @param options [Hash] Configuration options
+  # @option options [String] :cache_path Root path for GitHub conversation cache (required)
+  # @option options [String] :collection Qdrant collection name (required)
+  # @option options [String] :brain_path Path to brain folder with Reflections/, Snippets/, etc. (required)
+  # @option options [String] :start_date Start date for reflection (YYYY-MM-DD, default: 14 days ago)
+  # @option options [String] :end_date End date for reflection (YYYY-MM-DD, default: today)
+  # @option options [String] :purpose Purpose of reflection (default: catch-up)
+  # @option options [String] :name Reflection name (default: catch-up-YYYY-MM-DD)
+  # @option options [String] :resume_from Resume from existing reflection directory
+  # @option options [Boolean] :verbose Show debug logs (default: false)
+  # @option options [String] :llm_model LLM model for summaries and synthesis (default: ENV['LLM_MODEL'])
+  def self.start(options = {})
+    logger = options[:logger] || Log.logger
+
+    # Validate required arguments
+    unless options[:cache_path]
+      raise ArgumentError, "cache_path is required (path to GitHub conversation cache)"
+    end
+
+    unless options[:collection]
+      raise ArgumentError, "collection is required (Qdrant collection name)"
+    end
+
+    unless options[:brain_path]
+      raise ArgumentError, "brain_path is required (path to brain folder)"
+    end
+
+    # Validate paths exist
+    unless File.directory?(options[:cache_path])
+      raise ArgumentError, "cache_path does not exist: #{options[:cache_path]}"
+    end
+
+    unless File.directory?(options[:brain_path])
+      raise ArgumentError, "brain_path does not exist: #{options[:brain_path]}"
+    end
+
+    # Set up shared context
+    shared = {
+      cache_path: options[:cache_path],
+      collection: options[:collection],
+      brain_path: options[:brain_path],
+      start_date: options[:start_date],
+      end_date: options[:end_date],
+      purpose: options[:purpose] || "catch-up",
+      reflection_name: options[:reflection_name],
+      verbose: options[:verbose] || false,
+      llm_model: options[:llm_model] || ENV["LLM_MODEL"],
+      script_dir: options[:script_dir] || File.expand_path(File.dirname(__FILE__) + "/../bin"),
+      resume_from: options[:resume_from],
+      executive_summary_prompt_path: options[:executive_summary_prompt_path],
+      topics_prompt_path: options[:topics_prompt_path]
+    }
+
+    # Build the workflow
+    init_node = ReflectionAgent::InitializeNode.new(logger: logger)
+    snippets_loader = ReflectionAgent::SnippetsLoaderNode.new(logger: logger)
+    snippets_cluster = ReflectionAgent::SnippetsClusterNode.new(logger: logger)
+    cluster_snippet_summary = ReflectionAgent::ClusterSnippetSummaryNode.new(logger: logger)
+    conversations_loader = ReflectionAgent::ConversationsLoaderNode.new(logger: logger)
+    cluster_conversation_summary = ReflectionAgent::ClusterConversationSummaryNode.new(logger: logger)
+    final_synthesis = ReflectionAgent::FinalSynthesisNode.new(logger: logger)
+    end_node = ReflectionAgent::EndNode.new(logger: logger)
+
+    # Link the nodes in sequence
+    init_node.next(snippets_loader)
+    snippets_loader.next(snippets_cluster)
+    snippets_cluster.next(cluster_snippet_summary)
+    cluster_snippet_summary.next(conversations_loader)
+    conversations_loader.next(cluster_conversation_summary)
+    cluster_conversation_summary.next(final_synthesis)
+    final_synthesis.next(end_node)
+
+    # Create and run the flow
+    flow = Pocketflow::Flow.new(init_node)
+
+    logger.info "=== PERSONAL WORK REFLECTION AGENT v2 ==="
+    logger.info "Strategy: Hierarchical summarization starting with snippets"
+    logger.info "Cache path: #{options[:cache_path]}"
+    logger.info "Vector collection: #{options[:collection]}"
+    logger.info "Brain folder: #{options[:brain_path]}"
+    logger.info "LLM model: #{shared[:llm_model] || 'default'}"
+    logger.info ""
+    logger.info "⚠️  IMPORTANT: Ensure your vector index is up-to-date!"
+    logger.info "   This agent will load conversation summaries from Qdrant."
+    logger.info ""
+
+    flow.run(shared)
+  end
+end

--- a/lib/reflection_agent/cluster_conversation_summary_node.rb
+++ b/lib/reflection_agent/cluster_conversation_summary_node.rb
@@ -1,0 +1,249 @@
+module ReflectionAgent
+  # ClusterConversationSummaryNode - Summarizes GitHub conversations per cluster
+  #
+  # This node:
+  # 1. Takes cluster-organized conversations from previous stage
+  # 2. For each cluster: reads snippet summary + top N conversations
+  # 3. Uses LLM to extract conversation themes and patterns
+  # 4. Generates bounded summaries (~2KB per cluster) for final synthesis
+  #
+  # Uses ParallelBatchNode for concurrent cluster processing
+  #
+  # @example
+  #   node = ClusterConversationSummaryNode.new
+  #   cluster_data = node.prep(shared)
+  #   summaries = node.exec_batch(cluster)
+  #   node.post(shared, cluster_data, all_summaries)
+  class ClusterConversationSummaryNode < Pocketflow::ParallelBatchNode
+    attr_accessor :logger
+
+    def initialize(*args, logger: Log.logger, **kwargs)
+      super(*args, **kwargs)
+      @logger = logger
+    end
+
+    # Load cluster data from previous stages
+    #
+    # @param shared [Hash] Workflow context
+    # @return [Array<Hash>] Cluster data (or empty array if skipping)
+    def prep(shared)
+      @shared = shared
+      @skip_execution = false  # Initialize flag
+      logger.info "=== STAGE 5: SUMMARIZE CONVERSATIONS PER CLUSTER ==="
+
+      # Check if stage already completed
+      output_path = File.join(shared[:reflection_dir], "05-cluster-conversation-summaries.json")
+      if File.exist?(output_path)
+        logger.info "Stage 5 already completed, loading existing conversation summaries..."
+        existing_summaries = JSON.parse(File.read(output_path))
+
+        # Validate that summaries aren't corrupted (all nil values)
+        if existing_summaries.all?(&:nil?)
+          logger.warn "Existing summaries are corrupted (all nil), will regenerate..."
+          File.delete(output_path)
+          # Continue to normal processing (flag already false)
+        else
+          @skip_execution = true
+          @existing_summaries = existing_summaries
+          return []  # Empty array skips ParallelBatchNode execution
+        end
+      end
+
+      # Load cluster snippet summaries
+      snippet_summaries_path = File.join(shared[:reflection_dir], "03-cluster-snippet-summaries.json")
+      snippet_summaries = JSON.parse(File.read(snippet_summaries_path))
+
+      # Load cluster-organized conversations
+      conversations_path = File.join(shared[:reflection_dir], "04-conversations-by-cluster.json")
+      cluster_conversations = JSON.parse(File.read(conversations_path))
+
+      # Combine data for each cluster
+      clusters = snippet_summaries.map do |ss|
+        cluster_convs = cluster_conversations.find { |cc| cc["cluster_id"] == ss["cluster_id"] }
+
+        {
+          cluster_id: ss["cluster_id"],
+          cluster_name: ss["cluster_name"],
+          snippet_summary: ss["summary"],
+          conversations: cluster_convs ? cluster_convs["conversations"] : [],
+          snippet_summary_path: File.join(shared[:reflection_dir], "clusters", "#{ss['cluster_id']}-snippet-summary.md")
+        }
+      end
+
+      logger.info "Processing #{clusters.length} clusters in parallel"
+      logger.info ""
+
+      clusters
+    end
+
+    # Summarize conversations for one cluster
+    #
+    # @param cluster [Hash] Cluster data with snippet summary and conversations
+    # @return [Hash] Conversation summary for this cluster
+    def exec(cluster)
+      # Handle both symbol and string keys
+      cluster_id = cluster[:cluster_id] || cluster["cluster_id"]
+      cluster_name = cluster[:cluster_name] || cluster["cluster_name"]
+      conversations = cluster[:conversations] || cluster["conversations"] || []
+      snippet_summary_path = cluster[:snippet_summary_path] || cluster["snippet_summary_path"]
+
+      logger.info "  [Cluster #{cluster_id}] Summarizing conversations..."
+
+      # Filter to only found conversations and take top 20 by order (already scored in loader)
+      found_conversations = conversations
+        .select { |c| c["found"] }
+        .take(20)
+
+      if found_conversations.empty?
+        logger.info "  [Cluster #{cluster_id}] No conversations found, skipping"
+        return {
+          cluster_id: cluster_id,
+          cluster_name: cluster_name,
+          summary: "No GitHub conversations were referenced in this cluster's snippets.",
+          conversation_count: 0
+        }
+      end
+
+      # Read snippet summary for context
+      snippet_summary = File.read(snippet_summary_path)
+
+      # Build conversation context
+      conversations_text = found_conversations.map.with_index do |conv, idx|
+        "### Conversation #{idx + 1}: #{conv['url']}\n\n#{conv['summary']}"
+      end.join("\n\n---\n\n")
+
+      # Generate LLM prompt
+      prompt = Utils.fill_template(CLUSTER_CONVERSATION_SUMMARY_PROMPT, {
+        cluster_name: cluster_name,
+        snippet_summary: snippet_summary,
+        conversation_count: found_conversations.length,
+        conversations: conversations_text
+      })
+
+      # Call LLM (Utils.call_llm only accepts positional args: prompt, model)
+      summary = Utils.call_llm(prompt, @shared[:llm_model])
+
+      logger.info "  [Cluster #{cluster_id}] ✓ Generated summary (#{summary.length} chars)"
+
+      {
+        cluster_id: cluster_id,
+        cluster_name: cluster_name,
+        summary: summary,
+        conversation_count: found_conversations.length
+      }
+    end
+
+    # Write all conversation summaries to disk
+    #
+    # @param shared [Hash] Workflow context
+    # @param prep_res [Array<Hash>] Cluster data from prep
+    # @param exec_res [Array<Hash>] All conversation summaries
+    # @return [nil]
+    def post(shared, prep_res, exec_res)
+      # Use stored shared context (handles case where shared param might be nil)
+      ctx = shared || @shared
+
+      # If we skipped execution, use existing summaries
+      summaries = @skip_execution ? @existing_summaries : exec_res
+
+      # Handle nil or empty results
+      if summaries.nil? || summaries.empty?
+        logger.error "No conversation summaries available"
+        return nil
+      end
+
+      # Write files only if we didn't skip
+      unless @skip_execution
+        # Write combined JSON
+        output_path = File.join(ctx[:reflection_dir], "05-cluster-conversation-summaries.json")
+        File.write(output_path, JSON.pretty_generate(summaries))
+        logger.info "Wrote cluster conversation summaries: #{output_path}"
+
+        # Write individual markdown files
+        summaries.each do |summary|
+          # Skip nil summaries
+          if summary.nil?
+            logger.warn "Skipping nil summary in post()"
+            next
+          end
+
+          # Handle both symbol and string keys
+          cluster_id = summary[:cluster_id] || summary["cluster_id"]
+          summary_text = summary[:summary] || summary["summary"]
+
+          next unless cluster_id && summary_text
+
+          md_path = File.join(
+            ctx[:reflection_dir],
+            "clusters",
+            "#{cluster_id}-conversation-summary.md"
+          )
+          File.write(md_path, summary_text)
+        end
+        logger.info "Wrote individual conversation summary files to clusters/"
+      end
+
+      # Write ledger
+      total_conversations = summaries.sum { |s| s[:conversation_count] || s["conversation_count"] || 0 }
+      ledger = {
+        stage: "cluster_conversation_summary",
+        status: @skip_execution ? "resumed" : "completed",
+        cluster_count: summaries.length,
+        total_conversations: total_conversations,
+        next: "final_synthesis",
+        createdAt: Time.now.utc.iso8601
+      }
+      ledger_path = File.join(ctx[:reflection_dir], "stage-5-cluster-conversation-summary.ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      logger.info ""
+      if @skip_execution
+        logger.info "✓ Stage 5 resumed: Loaded #{total_conversations} existing conversation summaries across #{summaries.length} clusters"
+      else
+        logger.info "✓ Stage 5 complete: Summarized #{total_conversations} conversations across #{summaries.length} clusters"
+      end
+      logger.info "  Next: Final synthesis"
+      logger.info ""
+
+      nil
+    end
+
+    # LLM prompt for summarizing conversations within a cluster
+    CLUSTER_CONVERSATION_SUMMARY_PROMPT = <<~PROMPT
+      You are analyzing GitHub conversations (issues, PRs, discussions) from a specific time period.
+
+      ## CLUSTER: {{cluster_name}}
+
+      ### Context from Weekly Snippets
+      {{snippet_summary}}
+
+      ### GitHub Conversations ({{conversation_count}} total)
+      {{conversations}}
+
+      ## YOUR TASK
+
+      Analyze these {{conversation_count}} GitHub conversations and create a structured summary that identifies:
+
+      1. **Technical Themes** (3-5 bullets)
+         - What technical topics, technologies, or areas of work are represented?
+         - What systems, features, or components were being developed or discussed?
+
+      2. **Key Conversations** (3-7 bullets)
+         - Which conversations were most significant or impactful?
+         - What were the main outcomes, decisions, or learnings?
+         - Include the conversation URL in each bullet
+
+      3. **Collaboration Patterns** (2-4 bullets)
+         - Who were the key collaborators or teams involved?
+         - What types of interactions happened? (code review, design discussion, debugging, etc.)
+         - Any notable cross-team or cross-domain work?
+
+      4. **Connections to Snippets** (2-3 bullets)
+         - How do these conversations relate to what was highlighted in the snippets?
+         - Do the conversations provide additional context or depth to snippet items?
+
+      Keep the summary focused and use bullet points. Target ~1500-2000 characters total.
+      Be specific and technical - use actual feature names, technologies, and outcomes.
+    PROMPT
+  end
+end

--- a/lib/reflection_agent/cluster_snippet_summary_node.rb
+++ b/lib/reflection_agent/cluster_snippet_summary_node.rb
@@ -1,0 +1,217 @@
+module ReflectionAgent
+  # ClusterSnippetSummaryNode - Summarizes snippets within each cluster
+  #
+  # This node processes each cluster in parallel using ParallelBatchNode.
+  # For each cluster, an LLM reads all snippets and creates:
+  # - Main themes (3-5 bullets)
+  # - Key accomplishments (3-7 bullets)
+  # - Important URLs mentioned (for conversation loading)
+  # - Open questions/threads
+  #
+  # Output per cluster: ~1-2KB summary
+  #
+  # @example
+  #   node = ClusterSnippetSummaryNode.new
+  #   clusters = node.prep(shared)
+  #   summaries = node.exec(cluster) # Called per cluster in parallel
+  #   node.post(shared, clusters, summaries)
+  class ClusterSnippetSummaryNode < Pocketflow::ParallelBatchNode
+    attr_accessor :logger
+
+    def initialize(*args, logger: Log.logger, **kwargs)
+      super(*args, **kwargs)
+      @logger = logger
+    end
+
+    # Load clusters from previous stage
+    #
+    # @param shared [Hash] Workflow context
+    # @return [Array<Hash>] Clusters to process
+    def prep(shared)
+      @shared = shared
+      @skip_execution = false  # Initialize flag
+      logger.info "=== STAGE 3: SUMMARIZE CLUSTER SNIPPETS (PARALLEL) ==="
+
+      # Check if this stage already completed (for resume)
+      output_path = File.join(shared[:reflection_dir], "03-cluster-snippet-summaries.json")
+      if File.exist?(output_path)
+        logger.info "Stage 3 already completed, loading existing summaries..."
+        existing_summaries = JSON.parse(File.read(output_path))
+
+        # Validate that summaries aren't corrupted (all nil values)
+        if existing_summaries.all?(&:nil?)
+          logger.warn "Existing summaries are corrupted (all nil), will regenerate..."
+          File.delete(output_path)
+          # Continue to normal processing (flag already false)
+        else
+          logger.info "✓ Loaded #{existing_summaries.length} existing cluster summaries"
+          logger.info ""
+          # Return empty array to skip execution
+          @skip_execution = true
+          @existing_summaries = existing_summaries
+          return []
+        end
+      end
+
+      clusters_path = File.join(shared[:reflection_dir], "02-clusters.json")
+      clusters = JSON.parse(File.read(clusters_path))
+
+      logger.info "Processing #{clusters.length} clusters in parallel..."
+      logger.info ""
+
+      clusters
+    end
+
+    # Summarize one cluster's snippets using LLM
+    #
+    # @param cluster [Hash] Single cluster to summarize
+    # @return [Hash] Cluster summary
+    def exec(cluster)
+      cluster_id = cluster["id"]
+      logger.info "[#{cluster_id}] Summarizing #{cluster['snippets'].length} snippets..."
+
+      # Build combined snippets text
+      snippets_text = cluster["snippets"].map do |snippet|
+        "### #{snippet['title']}\n" \
+        "**Period**: #{snippet['start_date']} to #{snippet['end_date']}\n\n" \
+        "#{snippet['content']}\n\n" \
+        "---\n"
+      end.join("\n")
+
+      # Build prompt
+      prompt = Utils.fill_template(CLUSTER_SNIPPET_SUMMARY_PROMPT, {
+        cluster_name: cluster["name"],
+        cluster_period: "#{cluster['start_date']} to #{cluster['end_date']}",
+        snippets_count: cluster["snippets"].length,
+        snippets_text: snippets_text
+      })
+
+      # Call LLM
+      summary_text = Utils.call_llm(prompt, @shared[:llm_model])
+
+      # Extract URLs mentioned
+      urls = extract_urls(summary_text)
+
+      logger.info "[#{cluster_id}] ✓ Generated summary (#{urls.length} URLs extracted)"
+
+      {
+        cluster_id: cluster_id,
+        cluster_name: cluster["name"],
+        start_date: cluster["start_date"],
+        end_date: cluster["end_date"],
+        snippets_count: cluster["snippets"].length,
+        summary: summary_text,
+        urls_mentioned: urls
+      }
+    end
+
+    # Write all cluster summaries to disk
+    #
+    # @param shared [Hash] Workflow context
+    # @param prep_res [Array<Hash>] Clusters from prep
+    # @param exec_res [Array<Hash>] Cluster summaries
+    # @return [nil]
+    def post(shared, prep_res, exec_res)
+      # Use stored shared context (handles case where shared param might be nil)
+      ctx = shared || @shared
+
+      # If we skipped execution, use existing summaries
+      summaries = @skip_execution ? @existing_summaries : exec_res
+
+      # Write combined summaries (only if we didn't skip)
+      unless @skip_execution
+        summaries_path = File.join(ctx[:reflection_dir], "03-cluster-snippet-summaries.json")
+        File.write(summaries_path, JSON.pretty_generate(summaries))
+        logger.info ""
+        logger.info "Wrote cluster summaries: #{summaries_path}"
+
+        # Write individual cluster summary files
+        summaries.each do |summary|
+          cluster_file = File.join(
+            ctx[:reflection_dir],
+            "clusters",
+            "#{summary[:cluster_id]}-snippet-summary.md"
+          )
+          File.write(cluster_file, summary[:summary])
+        end
+      end
+
+      # Calculate total URLs (handle both symbol and string keys)
+      total_urls = summaries.sum { |s| (s[:urls_mentioned] || s["urls_mentioned"] || []).length }
+
+      # Write ledger
+      ledger = {
+        stage: "cluster_snippet_summary",
+        status: @skip_execution ? "resumed" : "completed",
+        summaries_count: summaries.length,
+        total_urls_extracted: total_urls,
+        next: "conversations_loader",
+        createdAt: Time.now.utc.iso8601
+      }
+      ledger_path = File.join(ctx[:reflection_dir], "stage-3-cluster-snippet-summary.ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      logger.info ""
+      if @skip_execution
+        logger.info "✓ Stage 3 resumed: Loaded #{summaries.length} existing cluster summaries"
+      else
+        logger.info "✓ Stage 3 complete: Summarized #{summaries.length} clusters"
+      end
+      logger.info "  Total URLs extracted: #{total_urls}"
+      logger.info "  Next: Load conversation summaries from vector DB"
+      logger.info ""
+
+      nil
+    end
+
+    private
+
+    # Extract GitHub URLs from text
+    #
+    # @param text [String] Text to extract URLs from
+    # @return [Array<String>] Unique GitHub URLs
+    def extract_urls(text)
+      urls = text.scan(%r{https://github\.com/[^\s\)]+})
+      urls.map { |url| url.chomp('.').chomp(',') }.uniq
+    end
+
+    # Prompt for cluster snippet summarization
+    CLUSTER_SNIPPET_SUMMARY_PROMPT = <<~PROMPT
+      You are analyzing a cluster of weekly work snippets for a personal reflection.
+
+      ## Cluster: {{cluster_name}}
+      **Period**: {{cluster_period}}
+      **Snippets**: {{snippets_count}}
+
+      ## Snippets Content
+
+      {{snippets_text}}
+
+      ## Summarization Tasks
+
+      Please create a concise summary with:
+
+      1. **Main Themes** (3-5 bullets)
+         - What were the dominant areas of focus in this period?
+         - What patterns emerge across these weeks?
+
+      2. **Key Accomplishments** (3-7 bullets)
+         - What significant work was completed?
+         - What decisions were made?
+         - What milestones were reached?
+
+      3. **GitHub URLs Referenced** (list)
+         - Extract all GitHub URLs mentioned in the snippets
+         - Include PRs, issues, discussions
+         - Format as a markdown list
+
+      4. **Open Threads** (2-4 bullets)
+         - What was in progress?
+         - What questions remained?
+         - What needed follow-up?
+
+      Keep the summary concise (≤500 words) but preserve important details and context.
+      The URLs list is critical - it will be used to load detailed conversation summaries.
+    PROMPT
+  end
+end

--- a/lib/reflection_agent/conversations_loader_node.rb
+++ b/lib/reflection_agent/conversations_loader_node.rb
@@ -1,0 +1,285 @@
+module ReflectionAgent
+  # ConversationsLoaderNode - Loads conversation summaries from vector DB
+  #
+  # This node:
+  # 1. Extracts all unique URLs from cluster summaries
+  # 2. Loads executive summaries from Qdrant vector DB
+  # 3. Associates conversations back to their source clusters
+  # 4. Deduplicates and prepares for per-cluster summarization
+  #
+  # @example
+  #   node = ConversationsLoaderNode.new
+  #   cluster_summaries = node.prep(shared)
+  #   conversations = node.exec(cluster_summaries)
+  #   node.post(shared, cluster_summaries, conversations)
+  class ConversationsLoaderNode < Pocketflow::Node
+    attr_accessor :logger
+
+    def initialize(*args, logger: Log.logger, **kwargs)
+      super(*args, **kwargs)
+      @logger = logger
+    end
+
+    # Load cluster summaries from previous stage
+    #
+    # @param shared [Hash] Workflow context
+    # @return [Array<Hash>] Cluster summaries with URLs (or nil if skipping)
+    def prep(shared)
+      @shared = shared
+      @skip_execution = false  # Initialize flag
+      logger.info "=== STAGE 4: LOAD CONVERSATIONS ==="
+
+      # Check if stage already completed
+      output_path = File.join(shared[:reflection_dir], "04-conversations-by-cluster.json")
+      if File.exist?(output_path)
+        logger.info "Stage 4 already completed, loading existing conversations..."
+        existing_data = JSON.parse(File.read(output_path))
+
+        # Validate that data isn't corrupted (all nil values or empty)
+        if existing_data.empty? || existing_data.all?(&:nil?)
+          logger.warn "Existing conversations are corrupted, will regenerate..."
+          File.delete(output_path)
+          # Also delete the all-conversations file if it exists
+          all_path = File.join(shared[:reflection_dir], "04-conversations-all.json")
+          File.delete(all_path) if File.exist?(all_path)
+          # Continue to normal processing (flag already false)
+        else
+          @skip_execution = true
+          @existing_conversations = existing_data
+          return nil  # Signal to skip execution
+        end
+      end
+
+      summaries_path = File.join(shared[:reflection_dir], "03-cluster-snippet-summaries.json")
+      JSON.parse(File.read(summaries_path))
+    end
+
+    # Load all conversations mentioned in snippets
+    #
+    # @param cluster_summaries [Array<Hash>] Cluster summaries with URLs (or nil if skipping)
+    # @return [Hash] Loaded conversations organized by cluster (or nil if skipping)
+    def exec(cluster_summaries)
+      return nil if @skip_execution
+
+      # Extract all unique URLs across all clusters
+      all_urls = cluster_summaries.flat_map { |cs| cs["urls_mentioned"] }.uniq
+      logger.info "Found #{all_urls.length} unique conversation URLs"
+
+      # Load summaries from vector DB
+      conversations = {}
+      all_urls.each_with_index do |url, idx|
+        if (idx + 1) % 10 == 0 || idx == all_urls.length - 1
+          logger.info "  Loading conversation #{idx + 1}/#{all_urls.length}..."
+        end
+
+        summary = fetch_summary_from_vector_db(url)
+        conversations[url] = {
+          url: url,
+          summary: summary,
+          found: summary != url # If summary == url, it wasn't found
+        }
+      end
+
+      # Count successes
+      found_count = conversations.values.count { |c| c[:found] }
+      logger.info ""
+      logger.info "Successfully loaded #{found_count}/#{all_urls.length} conversation summaries"
+      logger.info ""
+
+      # Organize conversations by cluster
+      cluster_conversations = cluster_summaries.map do |cs|
+        cluster_urls = cs["urls_mentioned"]
+        cluster_convs = cluster_urls.map { |url| conversations[url] }.compact
+
+        {
+          cluster_id: cs["cluster_id"],
+          cluster_name: cs["cluster_name"],
+          conversations: cluster_convs,
+          found_count: cluster_convs.count { |c| c[:found] },
+          total_count: cluster_urls.length
+        }
+      end
+
+      {
+        all_conversations: conversations,
+        cluster_conversations: cluster_conversations
+      }
+    end
+
+    # Write conversations data to disk
+    #
+    # @param shared [Hash] Workflow context
+    # @param prep_res [Array<Hash>] Cluster summaries from prep (or nil if skipping)
+    # @param exec_res [Hash] Loaded conversations (or nil if skipping)
+    # @return [nil]
+    def post(shared, prep_res, exec_res)
+      # Use stored shared context (handles case where shared param might be nil)
+      ctx = shared || @shared
+
+      # If we skipped execution, use existing conversations
+      if @skip_execution
+        conversations_data = @existing_conversations
+
+        # Calculate stats from existing data
+        total_conversations = conversations_data.sum { |cc| (cc["total_count"] || cc[:total_count] || 0) }
+        found_conversations = conversations_data.sum { |cc| (cc["found_count"] || cc[:found_count] || 0) }
+
+        # Write ledger
+        ledger = {
+          stage: "conversations_loader",
+          status: "resumed",
+          total_conversations: total_conversations,
+          found_in_vector_db: found_conversations,
+          next: "cluster_conversation_summary",
+          createdAt: Time.now.utc.iso8601
+        }
+        ledger_path = File.join(ctx[:reflection_dir], "stage-4-conversations-loader.ledger.json")
+        File.write(ledger_path, JSON.pretty_generate(ledger))
+
+        logger.info ""
+        logger.info "✓ Stage 4 resumed: Loaded #{found_conversations} existing conversations"
+        logger.info "  Next: Summarize conversations per cluster"
+        logger.info ""
+      else
+        # Write all conversations
+        all_path = File.join(ctx[:reflection_dir], "04-conversations-all.json")
+        File.write(all_path, JSON.pretty_generate(exec_res[:all_conversations]))
+        logger.info "Wrote all conversations: #{all_path}"
+
+        # Write cluster-organized conversations
+        cluster_path = File.join(ctx[:reflection_dir], "04-conversations-by-cluster.json")
+        File.write(cluster_path, JSON.pretty_generate(exec_res[:cluster_conversations]))
+        logger.info "Wrote cluster conversations: #{cluster_path}"
+
+        # Write ledger
+        total_found = exec_res[:all_conversations].values.count { |c| c[:found] }
+        ledger = {
+          stage: "conversations_loader",
+          status: "completed",
+          total_conversations: exec_res[:all_conversations].length,
+          found_in_vector_db: total_found,
+          next: "cluster_conversation_summary",
+          createdAt: Time.now.utc.iso8601
+        }
+        ledger_path = File.join(ctx[:reflection_dir], "stage-4-conversations-loader.ledger.json")
+        File.write(ledger_path, JSON.pretty_generate(ledger))
+
+        logger.info ""
+        logger.info "✓ Stage 4 complete: Loaded #{total_found} conversations"
+        logger.info "  Next: Summarize conversations per cluster"
+        logger.info ""
+      end
+
+      nil
+    end
+
+    private
+
+    # Fetch executive summary from vector DB, or fetch and index if not found
+    #
+    # @param url [String] Conversation URL
+    # @return [String] Executive summary or URL as fallback
+    def fetch_summary_from_vector_db(url)
+      # Use semantic search with URL filter to find this exact conversation
+      search_cmd = "#{@shared[:script_dir]}/semantic-search-github-conversations"
+      search_cmd += " #{Shellwords.escape(url)}"
+      search_cmd += " --collection #{Shellwords.escape(@shared[:collection])}"
+      search_cmd += " --filter #{Shellwords.escape("url:#{url}")}"
+      search_cmd += " --limit 1"
+      search_cmd += " --format json"
+
+      begin
+        output = Utils.run_cmd_safe(search_cmd)
+        results = JSON.parse(output)
+
+        if results.any? && results.first.dig("payload", "summary")
+          logger.debug "  ✓ Found summary for #{url}"
+          return results.first.dig("payload", "summary")
+        else
+          logger.warn "  ⚠ No summary found in vector DB for #{url}, fetching and indexing..."
+          return fetch_and_index_conversation(url)
+        end
+      rescue => e
+        logger.warn "  ⚠ Failed to fetch summary for #{url}: #{e.message}"
+        logger.warn "  Attempting to fetch and index..."
+        return fetch_and_index_conversation(url)
+      end
+    end
+
+    # Fetch and index a conversation that's not in the vector DB
+    #
+    # @param url [String] Conversation URL
+    # @return [String] Executive summary or URL as fallback
+    def fetch_and_index_conversation(url)
+      # Create JSON array with single conversation
+      conversation_json = JSON.generate([{ url: url }])
+
+      # Step 1: Fetch the conversation to cache
+      fetch_cmd = "#{@shared[:script_dir]}/fetch-github-conversations"
+      fetch_cmd += " --cache-path #{Shellwords.escape(@shared[:cache_path])}"
+
+      begin
+        IO.popen(fetch_cmd, "r+") do |io|
+          io.write(conversation_json)
+          io.close_write
+          io.read # Consume output
+        end
+
+        unless $?.success?
+          logger.warn "    ✗ Failed to fetch conversation"
+          return url
+        end
+      rescue => e
+        logger.warn "    ✗ Failed to fetch: #{e.message}"
+        return url
+      end
+
+      # Step 2: Index the conversation
+      index_cmd = "#{@shared[:script_dir]}/index-summaries"
+      index_cmd += " --executive-summary-prompt-path #{Shellwords.escape(@shared[:executive_summary_prompt_path])}"
+      index_cmd += " --topics-prompt-path #{Shellwords.escape(@shared[:topics_prompt_path])}"
+      index_cmd += " --collection #{Shellwords.escape(@shared[:collection])}"
+      index_cmd += " --cache-path #{Shellwords.escape(@shared[:cache_path])}"
+
+      begin
+        IO.popen(index_cmd, "r+") do |io|
+          io.write(conversation_json)
+          io.close_write
+          io.read # Consume output
+        end
+
+        unless $?.success?
+          logger.warn "    ✗ Failed to index conversation"
+          return url
+        end
+
+        logger.info "    ✓ Successfully fetched and indexed"
+      rescue => e
+        logger.warn "    ✗ Failed to index: #{e.message}"
+        return url
+      end
+
+      # Step 3: Try to retrieve the summary again
+      search_cmd = "#{@shared[:script_dir]}/semantic-search-github-conversations"
+      search_cmd += " #{Shellwords.escape(url)}"
+      search_cmd += " --collection #{Shellwords.escape(@shared[:collection])}"
+      search_cmd += " --filter #{Shellwords.escape("url:#{url}")}"
+      search_cmd += " --limit 1"
+      search_cmd += " --format json"
+
+      begin
+        output = Utils.run_cmd_safe(search_cmd)
+        results = JSON.parse(output)
+
+        if results.any? && results.first.dig("payload", "summary")
+          return results.first.dig("payload", "summary")
+        end
+      rescue => e
+        logger.warn "    ✗ Failed to retrieve after indexing: #{e.message}"
+      end
+
+      # Fallback: return URL
+      url
+    end
+  end
+end

--- a/lib/reflection_agent/end_node.rb
+++ b/lib/reflection_agent/end_node.rb
@@ -1,0 +1,141 @@
+module ReflectionAgent
+  # EndNode - Completes the reflection workflow
+  #
+  # This node:
+  # 1. Displays completion summary
+  # 2. Lists all generated files
+  # 3. Provides next steps for the user
+  #
+  # @example
+  #   node = EndNode.new
+  #   summary = node.prep(shared)
+  #   result = node.exec(summary)
+  #   node.post(shared, summary, result)
+  class EndNode < Pocketflow::Node
+    attr_accessor :logger
+
+    def initialize(*args, logger: Log.logger, **kwargs)
+      super(*args, **kwargs)
+      @logger = logger
+    end
+
+    # Gather completion summary
+    #
+    # @param shared [Hash] Workflow context
+    # @return [Hash] Summary data
+    def prep(shared)
+      @shared = shared
+      logger.info "=== STAGE 7: COMPLETION ==="
+
+      reflection_dir = shared[:reflection_dir]
+
+      # Count generated files
+      files = {
+        metadata: File.join(reflection_dir, "00-session-metadata.json"),
+        snippets: File.join(reflection_dir, "01-snippets.json"),
+        clusters: File.join(reflection_dir, "02-clusters.json"),
+        snippet_summaries: File.join(reflection_dir, "03-cluster-snippet-summaries.json"),
+        conversations_all: File.join(reflection_dir, "04-conversations-all.json"),
+        conversations_by_cluster: File.join(reflection_dir, "04-conversations-by-cluster.json"),
+        conversation_summaries: File.join(reflection_dir, "05-cluster-conversation-summaries.json"),
+        final_reflection: File.join(reflection_dir, "final-reflection.md")
+      }
+
+      # Count cluster files
+      cluster_dir = File.join(reflection_dir, "clusters")
+      cluster_files = Dir.glob(File.join(cluster_dir, "*")).sort if File.directory?(cluster_dir)
+
+      # Load metadata for stats
+      metadata_path = files[:metadata]
+      metadata = JSON.parse(File.read(metadata_path)) if File.exist?(metadata_path)
+
+      {
+        reflection_dir: reflection_dir,
+        files: files,
+        cluster_files: cluster_files || [],
+        metadata: metadata
+      }
+    end
+
+    # Display completion summary
+    #
+    # @param summary [Hash] Summary data from prep
+    # @return [Hash] Completion status
+    def exec(summary)
+      logger.info ""
+      logger.info "=" * 70
+      logger.info "  REFLECTION COMPLETE"
+      logger.info "=" * 70
+      logger.info ""
+      logger.info "Period: #{summary[:metadata]["start_date"]} to #{summary[:metadata]["end_date"]}"
+      logger.info "Purpose: #{summary[:metadata]["purpose"]}"
+      logger.info ""
+      logger.info "Output Directory:"
+      logger.info "  #{summary[:reflection_dir]}"
+      logger.info ""
+      logger.info "Generated Files:"
+      summary[:files].each do |name, path|
+        if File.exist?(path)
+          size = File.size(path)
+          logger.info "  ✓ #{File.basename(path)} (#{format_bytes(size)})"
+        end
+      end
+      logger.info ""
+      logger.info "Cluster Files (#{summary[:cluster_files].length} total):"
+      summary[:cluster_files].take(10).each do |path|
+        logger.info "  ✓ #{File.basename(path)}"
+      end
+      if summary[:cluster_files].length > 10
+        logger.info "  ... and #{summary[:cluster_files].length - 10} more"
+      end
+      logger.info ""
+      logger.info "=" * 70
+      logger.info ""
+      logger.info "Next Steps:"
+      logger.info "  1. Review the final reflection: #{summary[:files][:final_reflection]}"
+      logger.info "  2. Check individual cluster summaries in: #{File.join(summary[:reflection_dir], 'clusters')}"
+      logger.info "  3. Edit or annotate the reflection as needed"
+      logger.info "  4. Consider adding it to your permanent notes"
+      logger.info ""
+
+      { status: "completed", timestamp: Time.now.utc.iso8601 }
+    end
+
+    # Write final ledger
+    #
+    # @param shared [Hash] Workflow context
+    # @param prep_res [Hash] Summary from prep
+    # @param exec_res [Hash] Result from exec
+    # @return [nil]
+    def post(shared, prep_res, exec_res)
+      # Write final ledger
+      ledger = {
+        stage: "end",
+        status: "completed",
+        workflow: "reflection_agent_v2",
+        reflection_dir: prep_res[:reflection_dir],
+        createdAt: exec_res[:timestamp]
+      }
+      ledger_path = File.join(shared[:reflection_dir], "stage-7-end.ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      nil
+    end
+
+    private
+
+    # Format bytes into human-readable string
+    #
+    # @param bytes [Integer] File size in bytes
+    # @return [String] Formatted size
+    def format_bytes(bytes)
+      if bytes < 1024
+        "#{bytes}B"
+      elsif bytes < 1024 * 1024
+        "#{(bytes / 1024.0).round(1)}KB"
+      else
+        "#{(bytes / (1024.0 * 1024)).round(1)}MB"
+      end
+    end
+  end
+end

--- a/lib/reflection_agent/final_synthesis_node.rb
+++ b/lib/reflection_agent/final_synthesis_node.rb
@@ -1,0 +1,247 @@
+module ReflectionAgent
+  # FinalSynthesisNode - Generates the final reflection document
+  #
+  # This node:
+  # 1. Loads all cluster summaries (snippets + conversations)
+  # 2. Selects top 2-3 original snippets for grounding
+  # 3. Combines everything into ~20-25KB context
+  # 4. Uses LLM to generate comprehensive, structured reflection
+  #
+  # @example
+  #   node = FinalSynthesisNode.new
+  #   context = node.prep(shared)
+  #   reflection = node.exec(context)
+  #   node.post(shared, context, reflection)
+  class FinalSynthesisNode < Pocketflow::Node
+    attr_accessor :logger
+
+    def initialize(*args, logger: Log.logger, **kwargs)
+      super(*args, **kwargs)
+      @logger = logger
+    end
+
+    # Load all summaries and prepare synthesis context
+    #
+    # @param shared [Hash] Workflow context
+    # @return [Hash] All data (or nil if skipping)
+    def prep(shared)
+      @shared = shared
+      @skip_execution = false  # Initialize flag
+      logger.info "=== STAGE 6: FINAL SYNTHESIS ==="
+
+      # Check if stage already completed
+      output_path = File.join(shared[:reflection_dir], "final-reflection.md")
+      if File.exist?(output_path)
+        logger.info "Stage 6 already completed, loading existing reflection..."
+        existing_reflection = File.read(output_path)
+
+        # Validate that reflection isn't corrupted (empty or too short)
+        if existing_reflection.nil? || existing_reflection.strip.empty? || existing_reflection.length < 100
+          logger.warn "Existing reflection is corrupted or too short, will regenerate..."
+          File.delete(output_path)
+          # Continue to normal processing (flag already false)
+        else
+          @skip_execution = true
+          @existing_reflection = existing_reflection
+          return nil  # Signal to skip execution
+        end
+      end
+
+      # Load metadata
+      metadata_path = File.join(shared[:reflection_dir], "00-session-metadata.json")
+      metadata = JSON.parse(File.read(metadata_path))
+
+      # Load cluster snippet summaries
+      snippet_summaries_path = File.join(shared[:reflection_dir], "03-cluster-snippet-summaries.json")
+      snippet_summaries = JSON.parse(File.read(snippet_summaries_path))
+
+      # Load cluster conversation summaries
+      conversation_summaries_path = File.join(shared[:reflection_dir], "05-cluster-conversation-summaries.json")
+      conversation_summaries = JSON.parse(File.read(conversation_summaries_path))
+
+      # Load original snippets for grounding
+      snippets_path = File.join(shared[:reflection_dir], "01-snippets.json")
+      all_snippets = JSON.parse(File.read(snippets_path))
+
+      # Select top 2-3 snippets (most recent and longest)
+      selected_snippets = all_snippets
+        .sort_by { |s| [s["end_date"], -s["content"].length] }
+        .reverse
+        .take(3)
+
+      logger.info "Loaded #{snippet_summaries.length} cluster summaries"
+      logger.info "Selected #{selected_snippets.length} snippets for grounding"
+      logger.info ""
+
+      {
+        metadata: metadata,
+        snippet_summaries: snippet_summaries,
+        conversation_summaries: conversation_summaries,
+        selected_snippets: selected_snippets
+      }
+    end
+
+    # Generate final reflection document
+    #
+    # @param context [Hash] All summaries and metadata (or nil if skipping)
+    # @return [String] Final reflection markdown (or nil if skipping)
+    def exec(context)
+      return nil if @skip_execution
+
+      logger.info "Generating final reflection document..."
+
+      # Build cluster summaries section
+      cluster_sections = context[:snippet_summaries].map do |ss|
+        conv_summary = context[:conversation_summaries].find { |cs| cs["cluster_id"] == ss["cluster_id"] }
+
+        <<~SECTION
+          ### #{ss["cluster_name"]}
+
+          #### From Weekly Snippets
+          #{ss["summary"]}
+          #### From GitHub Conversations
+          #{conv_summary ? conv_summary["summary"] : "No conversations found for this cluster."}
+        SECTION
+      end.join("\n---\n\n")
+
+      # Build selected snippets section
+      snippets_text = context[:selected_snippets].map.with_index do |snippet, idx|
+        <<~SNIPPET
+          #### Snippet #{idx + 1}: #{snippet["start_date"]} to #{snippet["end_date"]}
+          #{snippet["content"]}
+        SNIPPET
+      end.join("\n---\n\n")
+
+      # Generate LLM prompt
+      prompt = Utils.fill_template(FINAL_SYNTHESIS_PROMPT, {
+        start_date: context[:metadata]["start_date"],
+        end_date: context[:metadata]["end_date"],
+        purpose: context[:metadata]["purpose"],
+        cluster_count: context[:snippet_summaries].length,
+        cluster_summaries: cluster_sections,
+        selected_snippets: snippets_text
+      })
+
+      # Call LLM (Utils.call_llm only accepts positional args: prompt, model)
+      reflection = Utils.call_llm(prompt, @shared[:llm_model])
+
+      logger.info "✓ Generated reflection (#{reflection.length} chars)"
+      logger.info ""
+
+      reflection
+    end
+
+    # Write final reflection to disk
+    #
+    # @param shared [Hash] Workflow context
+    # @param prep_res [Hash] Context from prep
+    # @param exec_res [String] Final reflection
+    # @return [nil]
+    def post(shared, prep_res, exec_res)
+      # Use stored shared context (handles case where shared param might be nil)
+      ctx = shared || @shared
+
+      # If we skipped execution, use existing reflection
+      reflection_text = @skip_execution ? @existing_reflection : exec_res
+
+      # Write final reflection (only if we didn't skip)
+      output_path = File.join(ctx[:reflection_dir], "final-reflection.md")
+      unless @skip_execution
+        File.write(output_path, reflection_text)
+        logger.info "Wrote final reflection: #{output_path}"
+      end
+
+      # Write ledger
+      ledger = {
+        stage: "final_synthesis",
+        status: @skip_execution ? "resumed" : "completed",
+        reflection_length: reflection_text.length,
+        output_file: output_path,
+        next: "end",
+        createdAt: Time.now.utc.iso8601
+      }
+      ledger_path = File.join(ctx[:reflection_dir], "stage-6-final-synthesis.ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      logger.info ""
+      if @skip_execution
+        logger.info "✓ Stage 6 resumed: Loaded existing final reflection"
+      else
+        logger.info "✓ Stage 6 complete: Final reflection generated"
+      end
+      logger.info "  Output: #{output_path}"
+      logger.info ""
+
+      nil
+    end
+
+    # LLM prompt for final synthesis
+    FINAL_SYNTHESIS_PROMPT = <<~PROMPT
+      You are creating a comprehensive personal work reflection for the period from {{start_date}} to {{end_date}}.
+
+      ## PURPOSE
+      {{purpose}}
+
+      ## CLUSTER SUMMARIES ({{cluster_count}} total)
+
+      The work has been organized into {{cluster_count}} temporal clusters. Each cluster includes:
+      - Themes and accomplishments from weekly snippets (curated highlights)
+      - Key GitHub conversations (issues, PRs, discussions) that were referenced
+
+      {{cluster_summaries}}
+
+      ## SELECTED ORIGINAL SNIPPETS
+
+      For additional context and grounding, here are some of the original weekly snippets:
+
+      {{selected_snippets}}
+
+      ## YOUR TASK
+
+      Create a comprehensive, well-structured reflection document that synthesizes all of this information.
+      Use the following structure:
+
+      ### 1. Executive Summary (3-4 paragraphs)
+      - High-level overview of the entire period
+      - Major themes and accomplishments
+      - Key transitions or shifts in focus
+      - Overall narrative arc
+
+      ### 2. Timeline & Phases
+      - Break the period into logical phases or themes
+      - For each phase: main focus areas, key outcomes, notable challenges
+      - Use the cluster summaries to identify natural divisions
+
+      ### 3. Technical Deep Dives (3-5 sections)
+      - Pick the 3-5 most significant technical areas
+      - For each: what was built/learned, key decisions, outcomes
+      - Include specific GitHub conversations where relevant
+      - Be technical and specific - use actual feature names, technologies, etc.
+
+      ### 4. Collaboration & Impact
+      - Key collaborations and partnerships
+      - Cross-team or cross-domain work
+      - Impact on others or broader organization
+      - Mentorship or knowledge sharing
+
+      ### 5. Patterns & Insights
+      - What patterns emerge across the clusters?
+      - What worked well? What was challenging?
+      - Key learnings or shifts in thinking
+      - Connections between different work streams
+
+      ### 6. Looking Forward
+      - Open threads or unfinished work
+      - Emerging themes or areas of interest
+      - Questions or areas for future exploration
+
+      ## GUIDELINES
+      - Be specific and technical - this is for your own reference
+      - Use bullet points and structured sections for readability
+      - Include relevant GitHub URLs when referencing specific work
+      - Aim for 2000-3000 words total
+      - Write in first person ("I worked on...", "We built...")
+      - Focus on substance over style - clarity and completeness matter most
+    PROMPT
+  end
+end

--- a/lib/reflection_agent/initialize_node.rb
+++ b/lib/reflection_agent/initialize_node.rb
@@ -1,0 +1,141 @@
+module ReflectionAgent
+  # InitializeNode - Sets up reflection session and directory structure
+  #
+  # Creates the reflection directory structure and writes session metadata.
+  # Handles date defaults and resume scenarios.
+  #
+  # @example
+  #   node = InitializeNode.new
+  #   metadata = node.prep(shared)
+  #   result = node.exec(metadata)
+  #   node.post(shared, metadata, result)
+  class InitializeNode < Pocketflow::Node
+    attr_accessor :logger
+
+    def initialize(*args, logger: Log.logger, **kwargs)
+      super(*args, **kwargs)
+      @logger = logger
+    end
+
+    # Prepare initialization by gathering inputs and setting defaults
+    #
+    # @param shared [Hash] Workflow context
+    # @return [Hash] Metadata configuration
+    def prep(shared)
+      logger.info "=== STAGE 0: INITIALIZE ==="
+
+      # Check if resuming from existing reflection
+      if shared[:resume_from] && File.directory?(shared[:resume_from])
+        logger.info "Resuming from existing reflection: #{shared[:resume_from]}"
+        metadata_path = File.join(shared[:resume_from], "00-session-metadata.json")
+
+        if File.exist?(metadata_path)
+          metadata = JSON.parse(File.read(metadata_path))
+          shared[:reflection_dir] = shared[:resume_from]
+          return metadata
+        else
+          logger.warn "Metadata file not found in resume directory, starting fresh"
+        end
+      end
+
+      # Calculate date defaults
+      end_date = shared[:end_date] || Date.today.to_s
+      start_date = shared[:start_date] || (Date.today - 14).to_s
+
+      # Apply defaults
+      purpose = shared[:purpose] || "catch-up"
+      reflection_name = shared[:reflection_name] || "catch-up-#{end_date}"
+
+      logger.info "Date range: #{start_date} to #{end_date}"
+      logger.info "Purpose: #{purpose}"
+      logger.info "Name: #{reflection_name}"
+
+      # Build metadata structure
+      {
+        startDate: start_date,
+        endDate: end_date,
+        purpose: purpose,
+        reflectionName: reflection_name,
+        sessionCount: 1,
+        currentStage: "initialize",
+        stages: {
+          initialize: "in-progress",
+          snippets_loader: "not-started",
+          snippets_cluster: "not-started",
+          cluster_snippet_summary: "not-started",
+          conversations_loader: "not-started",
+          cluster_conversation_summary: "not-started",
+          final_synthesis: "not-started"
+        },
+        createdAt: Time.now.utc.iso8601,
+        lastUpdated: Time.now.utc.iso8601,
+        brain_path: shared[:brain_path]
+      }
+    end
+
+    # Create directory structure and write metadata
+    #
+    # @param metadata [Hash] Metadata from prep
+    # @return [Hash] Result with paths
+    def exec(metadata)
+      # Build reflection directory path
+      dir_name = "#{metadata[:startDate]}__to__#{metadata[:endDate]}__#{metadata[:reflectionName]}"
+      reflection_dir = File.join(
+        metadata[:brain_path],
+        "Reflections",
+        dir_name
+      )
+
+      # Create directory structure
+      FileUtils.mkdir_p(reflection_dir)
+      FileUtils.mkdir_p(File.join(reflection_dir, "clusters"))
+
+      logger.info "Created reflection directory: #{reflection_dir}"
+
+      # Update metadata
+      metadata[:stages][:initialize] = "completed"
+      metadata[:currentStage] = "snippets_loader"
+      metadata[:lastUpdated] = Time.now.utc.iso8601
+
+      # Write metadata file
+      metadata_path = File.join(reflection_dir, "00-session-metadata.json")
+      File.write(metadata_path, JSON.pretty_generate(metadata))
+      logger.info "Wrote metadata: #{metadata_path}"
+
+      # Write stage ledger
+      ledger = {
+        stage: "initialize",
+        status: "completed",
+        next: "snippets_loader",
+        createdAt: Time.now.utc.iso8601
+      }
+      ledger_path = File.join(reflection_dir, "stage-0-init.ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      {
+        reflection_dir: reflection_dir,
+        metadata_path: metadata_path,
+        ledger_path: ledger_path
+      }
+    end
+
+    # Store reflection directory in shared context
+    #
+    # @param shared [Hash] Workflow context to update
+    # @param prep_res [Hash] Metadata from prep
+    # @param exec_res [Hash] Result from exec
+    # @return [nil]
+    def post(shared, prep_res, exec_res)
+      shared[:reflection_dir] = exec_res[:reflection_dir]
+      shared[:start_date] = prep_res[:startDate]
+      shared[:end_date] = prep_res[:endDate]
+
+      logger.info ""
+      logger.info "✓ Initialized: #{prep_res[:startDate]} → #{prep_res[:endDate]}"
+      logger.info "  #{exec_res[:reflection_dir]}"
+      logger.info ""
+
+      nil
+    end
+  end
+end

--- a/lib/reflection_agent/snippets_cluster_node.rb
+++ b/lib/reflection_agent/snippets_cluster_node.rb
@@ -1,0 +1,217 @@
+module ReflectionAgent
+  # SnippetsClusterNode - Groups snippets into temporal clusters
+  #
+  # This node creates 4-6 clusters of snippets based on time periods.
+  # For shorter reflections (≤4 weeks), uses weekly clusters.
+  # For longer reflections, groups into monthly or multi-week chunks.
+  #
+  # Goal: Each cluster should have 3-8 snippets for optimal LLM processing.
+  #
+  # @example
+  #   node = SnippetsClusterNode.new
+  #   snippets = node.prep(shared)
+  #   clusters = node.exec(snippets)
+  #   node.post(shared, snippets, clusters)
+  class SnippetsClusterNode < Pocketflow::Node
+    attr_accessor :logger
+
+    def initialize(*args, logger: Log.logger, **kwargs)
+      super(*args, **kwargs)
+      @logger = logger
+    end
+
+    # Load snippets from previous stage
+    #
+    # @param shared [Hash] Workflow context
+    # @return [Array<Hash>] Loaded snippets
+    def prep(shared)
+      @shared = shared
+      logger.info "=== STAGE 2: CLUSTER SNIPPETS ==="
+
+      snippets_path = File.join(shared[:reflection_dir], "01-snippets.json")
+      JSON.parse(File.read(snippets_path))
+    end
+
+    # Create temporal clusters of snippets
+    #
+    # @param snippets [Array<Hash>] Snippets from prep
+    # @return [Array<Hash>] Clusters with assigned snippets
+    def exec(snippets)
+      return [] if snippets.empty?
+
+      start_date = Date.parse(@shared[:start_date])
+      end_date = Date.parse(@shared[:end_date])
+      total_days = (end_date - start_date).to_i + 1
+
+      logger.info "Date range: #{total_days} days (#{start_date} to #{end_date})"
+      logger.info "Total snippets: #{snippets.length}"
+
+      # Determine clustering strategy based on time span
+      clusters = if total_days <= 28
+        # ≤4 weeks: Weekly clusters
+        cluster_by_weeks(snippets, start_date, end_date)
+      elsif total_days <= 90
+        # ≤3 months: Bi-weekly clusters
+        cluster_by_period(snippets, start_date, end_date, 14)
+      elsif total_days <= 180
+        # ≤6 months: Monthly clusters
+        cluster_by_months(snippets, start_date, end_date)
+      else
+        # >6 months: 6-week clusters
+        cluster_by_period(snippets, start_date, end_date, 42)
+      end
+
+      logger.info ""
+      logger.info "Created #{clusters.length} clusters:"
+      clusters.each do |cluster|
+        logger.info "  #{cluster[:name]}: #{cluster[:snippets].length} snippets"
+      end
+      logger.info ""
+
+      clusters
+    end
+
+    # Write clusters to disk
+    #
+    # @param shared [Hash] Workflow context
+    # @param prep_res [Array<Hash>] Snippets from prep
+    # @param exec_res [Array<Hash>] Clusters
+    # @return [nil]
+    def post(shared, prep_res, exec_res)
+      # Write clusters metadata
+      clusters_path = File.join(shared[:reflection_dir], "02-clusters.json")
+      File.write(clusters_path, JSON.pretty_generate(exec_res))
+      logger.info "Wrote clusters: #{clusters_path}"
+
+      # Write ledger
+      ledger = {
+        stage: "snippets_cluster",
+        status: "completed",
+        clusters_count: exec_res.length,
+        next: "cluster_snippet_summary",
+        createdAt: Time.now.utc.iso8601
+      }
+      ledger_path = File.join(shared[:reflection_dir], "stage-2-snippets-cluster.ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      logger.info ""
+      logger.info "✓ Stage 2 complete: Created #{exec_res.length} clusters"
+      logger.info "  Next: Summarize each cluster's snippets"
+      logger.info ""
+
+      nil
+    end
+
+    private
+
+    # Cluster snippets by week
+    #
+    # @param snippets [Array<Hash>] All snippets
+    # @param start_date [Date] Period start
+    # @param end_date [Date] Period end
+    # @return [Array<Hash>] Weekly clusters
+    def cluster_by_weeks(snippets, start_date, end_date)
+      clusters = []
+      current = start_date
+
+      while current <= end_date
+        week_end = [current + 6, end_date].min
+        week_snippets = snippets.select do |s|
+          snippet_start = Date.parse(s["start_date"])
+          snippet_end = Date.parse(s["end_date"])
+          # Snippet overlaps with this week
+          snippet_start <= week_end && snippet_end >= current
+        end
+
+        if week_snippets.any?
+          clusters << {
+            id: "week-#{current.strftime('%Y-%m-%d')}",
+            name: "Week of #{current.strftime('%b %d, %Y')}",
+            start_date: current.to_s,
+            end_date: week_end.to_s,
+            snippets: week_snippets
+          }
+        end
+
+        current += 7
+      end
+
+      clusters
+    end
+
+    # Cluster snippets by month
+    #
+    # @param snippets [Array<Hash>] All snippets
+    # @param start_date [Date] Period start
+    # @param end_date [Date] Period end
+    # @return [Array<Hash>] Monthly clusters
+    def cluster_by_months(snippets, start_date, end_date)
+      clusters = []
+      current = Date.new(start_date.year, start_date.month, 1)
+
+      while current <= end_date
+        month_end = Date.new(current.year, current.month, -1)
+        month_end = [month_end, end_date].min
+
+        month_snippets = snippets.select do |s|
+          snippet_start = Date.parse(s["start_date"])
+          snippet_end = Date.parse(s["end_date"])
+          snippet_start <= month_end && snippet_end >= current
+        end
+
+        if month_snippets.any?
+          clusters << {
+            id: "month-#{current.strftime('%Y-%m')}",
+            name: current.strftime('%B %Y'),
+            start_date: [current, start_date].max.to_s,
+            end_date: month_end.to_s,
+            snippets: month_snippets
+          }
+        end
+
+        # Move to next month
+        current = current.next_month
+      end
+
+      clusters
+    end
+
+    # Cluster snippets by fixed period (days)
+    #
+    # @param snippets [Array<Hash>] All snippets
+    # @param start_date [Date] Period start
+    # @param end_date [Date] Period end
+    # @param period_days [Integer] Days per cluster
+    # @return [Array<Hash>] Period clusters
+    def cluster_by_period(snippets, start_date, end_date, period_days)
+      clusters = []
+      current = start_date
+      cluster_num = 1
+
+      while current <= end_date
+        period_end = [current + period_days - 1, end_date].min
+
+        period_snippets = snippets.select do |s|
+          snippet_start = Date.parse(s["start_date"])
+          snippet_end = Date.parse(s["end_date"])
+          snippet_start <= period_end && snippet_end >= current
+        end
+
+        if period_snippets.any?
+          clusters << {
+            id: "period-#{cluster_num}",
+            name: "#{current.strftime('%b %d')} - #{period_end.strftime('%b %d, %Y')}",
+            start_date: current.to_s,
+            end_date: period_end.to_s,
+            snippets: period_snippets
+          }
+          cluster_num += 1
+        end
+
+        current += period_days
+      end
+
+      clusters
+    end
+  end
+end

--- a/lib/reflection_agent/snippets_loader_node.rb
+++ b/lib/reflection_agent/snippets_loader_node.rb
@@ -1,0 +1,189 @@
+module ReflectionAgent
+  # SnippetsLoaderNode - Loads all weekly snippets within date range
+  #
+  # This node scans the Snippets folder and loads all snippet files that
+  # overlap with the reflection period. Snippets are the PRIMARY signal
+  # for the reflection - they represent what you already deemed important.
+  #
+  # Supports two formats:
+  # - Single files: YYYY-MM-DD-to-YYYY-MM-DD.md
+  # - Folders: YYYY-MM-DD-to-YYYY-MM-DD/snippets.md (or final_snippet.md, etc.)
+  #
+  # @example
+  #   node = SnippetsLoaderNode.new
+  #   snippets_path = node.prep(shared)
+  #   snippets = node.exec(snippets_path)
+  #   node.post(shared, snippets_path, snippets)
+  class SnippetsLoaderNode < Pocketflow::Node
+    attr_accessor :logger
+
+    def initialize(*args, logger: Log.logger, **kwargs)
+      super(*args, **kwargs)
+      @logger = logger
+    end
+
+    # Get snippets directory path
+    #
+    # @param shared [Hash] Workflow context
+    # @return [String] Path to Snippets folder
+    def prep(shared)
+      @shared = shared
+      logger.info "=== STAGE 1: LOAD SNIPPETS ==="
+
+      File.join(shared[:brain_path], "Snippets")
+    end
+
+    # Scan and load all relevant snippets
+    #
+    # @param snippets_path [String] Path from prep
+    # @return [Array<Hash>] Loaded snippets
+    def exec(snippets_path)
+      start_date = Date.parse(@shared[:start_date])
+      end_date = Date.parse(@shared[:end_date])
+      snippets = []
+
+      unless File.directory?(snippets_path)
+        logger.warn "Snippets directory not found: #{snippets_path}"
+        return snippets
+      end
+
+      # Pattern 1: Single markdown files (YYYY-MM-DD-to-YYYY-MM-DD.md)
+      Dir.glob(File.join(snippets_path, "*.md")).each do |file|
+        filename = File.basename(file, ".md")
+        dates = extract_date_range_from_name(filename)
+
+        if dates && dates[:start] <= end_date && dates[:end] >= start_date
+          snippets << {
+            path: file,
+            start_date: dates[:start].to_s,
+            end_date: dates[:end].to_s,
+            title: filename,
+            content: File.read(file),
+            source: "file"
+          }
+          logger.info "  ✨ Loaded snippet: #{filename}"
+        end
+      end
+
+      # Pattern 2: Folders with snippet files inside
+      Dir.glob(File.join(snippets_path, "*")).each do |folder|
+        next unless File.directory?(folder)
+
+        folder_name = File.basename(folder)
+        dates = extract_date_range_from_name(folder_name)
+
+        next unless dates && dates[:start] <= end_date && dates[:end] >= start_date
+
+                # Priority order for snippet files in folders
+        snippet_files = [
+          "final_snippet.md",
+          "snippets.md",
+          "09_snippets.md",
+          "08_snippets.md",
+          "07_snippets.md",
+          "output.md",
+          "draft.md"
+        ]
+
+        found = false
+        snippet_files.each do |snippet_file|
+          file_path = File.join(folder, snippet_file)
+          if File.exist?(file_path)
+            snippets << {
+              path: file_path,
+              start_date: dates[:start].to_s,
+              end_date: dates[:end].to_s,
+              title: "#{folder_name}/#{snippet_file}",
+              content: File.read(file_path),
+              source: "folder"
+            }
+            logger.info "  ✨ Loaded snippet: #{folder_name}/#{snippet_file}"
+            found = true
+            break # Only take the first matching file
+          end
+        end
+
+        # Fallback: find any .md file in the directory
+        unless found
+          md_files = Dir.glob(File.join(folder, "*.md")).sort.reverse
+          if md_files.any?
+            file_path = md_files.first
+            snippets << {
+              path: file_path,
+              start_date: dates[:start].to_s,
+              end_date: dates[:end].to_s,
+              title: "#{folder_name}/#{File.basename(file_path)}",
+              content: File.read(file_path),
+              source: "folder"
+            }
+            logger.info "  ✨ Loaded snippet: #{folder_name}/#{File.basename(file_path)}"
+          end
+        end
+      end
+
+      # Sort by start date
+      snippets.sort_by! { |s| s[:start_date] }
+
+      logger.info ""
+      logger.info "Loaded #{snippets.length} snippets total"
+      logger.info ""
+
+      snippets
+    end
+
+    # Write snippets to disk and update shared context
+    #
+    # @param shared [Hash] Workflow context
+    # @param prep_res [String] Snippets path from prep
+    # @param exec_res [Array<Hash>] Loaded snippets
+    # @return [nil]
+    def post(shared, prep_res, exec_res)
+      # Write snippets data
+      snippets_path = File.join(shared[:reflection_dir], "01-snippets.json")
+      File.write(snippets_path, JSON.pretty_generate(exec_res))
+      logger.info "Wrote snippets: #{snippets_path}"
+
+      # Write ledger
+      ledger = {
+        stage: "snippets_loader",
+        status: "completed",
+        snippets_count: exec_res.length,
+        next: "snippets_cluster",
+        createdAt: Time.now.utc.iso8601
+      }
+      ledger_path = File.join(shared[:reflection_dir], "stage-1-snippets-loader.ledger.json")
+      File.write(ledger_path, JSON.pretty_generate(ledger))
+
+      logger.info ""
+      logger.info "✓ Stage 1 complete: Loaded #{exec_res.length} snippets"
+      logger.info "  Next: Cluster snippets by theme"
+      logger.info ""
+
+      nil
+    end
+
+    private
+
+    # Extract date range from snippet folder/file name
+    #
+    # @param name [String] Folder or filename
+    # @return [Hash, nil] Hash with :start and :end dates, or nil
+    def extract_date_range_from_name(name)
+      # Pattern: YYYY-MM-DD-to-YYYY-MM-DD (with optional leading zeros)
+      if match = name.match(/(\d{4}-\d{1,2}-\d{1,2})-to-(\d{4}-\d{1,2}-\d{1,2})/)
+        begin
+          # Normalize dates (add leading zeros if needed)
+          start_str = match[1].split('-').map { |p| p.rjust(p.length < 3 ? 2 : 4, '0') }.join('-')
+          end_str = match[2].split('-').map { |p| p.rjust(p.length < 3 ? 2 : 4, '0') }.join('-')
+
+          {
+            start: Date.parse(start_str),
+            end: Date.parse(end_str)
+          }
+        rescue Date::Error
+          nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why?
Previously, our system lacked an automated way to synthesize long-term engineering reflections from weekly snippets and related GitHub conversations. There was no existing workflow to cluster, summarize, or cross-reference data across time.

## How?
This PR introduces a fully hierarchical personal reflection pipeline:
- Adds `bin/reflection-agent`, a CLI orchestration script for multi-stage reflection workflows, including configuration, date range selection, purpose, cache integration, and resumable execution.
- Implements a new agent module (`lib/reflection_agent.rb`) composed of modular nodes (`lib/reflection_agent/`) to:
  - Load personal reflection snippets and related GitHub conversations (Qdrant vector DB).
  - Cluster snippets temporally; summarize clusters and conversations with LLMs.
  - Synthesize comprehensive executive and technical reflection documents.
- Supports robust logging, error handling, template prompts, and ledgering for resumability across large time spans.

### Testing
- Manual invocation using `bin/reflection-agent` with a variety of date ranges.
- Verified pipeline handles 6 months of snippets, caches intermediate stages, and generates final summaries.
